### PR TITLE
Add support for RViz-like colormaps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2422,6 +2422,7 @@ dependencies = [
  "fast_image_resize",
  "image",
  "imageproc",
+ "lazy_static",
  "log",
  "serde",
  "serde_yaml_ng",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ egui_kittest = { version = "0.31.0", features = ["wgpu", "snapshot", "eframe"] }
 egui_tiles = "0.12.0"
 env_logger = "0.11.5"
 fast_image_resize = { version = "5.1.1", features = ["image"] }
+lazy_static = "1.5.0"
 image = { version = "0.25.5", features = ["jpeg", "png", "pnm"] }
 imageproc = "0.25.0"
 log = "0.4.22 "

--- a/src/app_impl/tint_settings.rs
+++ b/src/app_impl/tint_settings.rs
@@ -163,6 +163,7 @@ fn pick(
     ui.checkbox(edit_value_interpretation, "");
     if *edit_value_interpretation {
         ui.end_row();
+        ui.end_row();
         pick_value_interpretation(ui, value_interpretation);
     }
 }

--- a/src/app_impl/tint_settings.rs
+++ b/src/app_impl/tint_settings.rs
@@ -226,8 +226,8 @@ fn pick_colormap(ui: &mut egui::Ui, colormap: &mut ColorMap) {
                 .on_hover_text("Classic RViz map coloring.");
             ui.selectable_value(colormap, ColorMap::RvizCostmap, "RViz \"Costmap\"")
                 .on_hover_text("Classic RViz costmap coloring.");
-            ui.selectable_value(colormap, ColorMap::RvizRaw, "RViz \"Raw\"")
-                .on_hover_text("Classic RViz raw color map (aka: no coloring).");
+            ui.selectable_value(colormap, ColorMap::Raw, "Raw")
+                .on_hover_text("No coloring.");
             ui.selectable_value(colormap, ColorMap::CoolCostmap, "Cool costmap")
                 .on_hover_text("Alternative costmap coloring with less screaming colors.");
         });

--- a/src/image.rs
+++ b/src/image.rs
@@ -115,10 +115,10 @@ pub fn color_to_alpha(img: &mut image::DynamicImage, color: Option<egui::Color32
     }
 }
 
-pub fn add_alpha_if_needed(img: image::DynamicImage) -> image::DynamicImage {
+pub fn to_rgba8(img: image::DynamicImage) -> image::DynamicImage {
     match img.color() {
-        image::ColorType::L8 => image::DynamicImage::from(img.to_luma_alpha8()),
-        image::ColorType::La8 => img,
+        image::ColorType::L8 => image::DynamicImage::from(img.to_rgba8()),
+        image::ColorType::La8 => image::DynamicImage::from(img.to_rgba8()),
         image::ColorType::Rgb8 => image::DynamicImage::from(img.to_rgba8()),
         image::ColorType::Rgba8 => img,
         _ => panic!("Unsupported color type: {:?}", img.color()),

--- a/src/image_pyramid.rs
+++ b/src/image_pyramid.rs
@@ -18,11 +18,14 @@ pub struct ImagePyramid {
     levels_by_size: HashMap<u32, image::DynamicImage>,
     aspect_ratio: f32,
     original_size: egui::Vec2,
+    pub original_has_alpha: bool,
 }
 
 impl ImagePyramid {
     pub fn new(original: image::DynamicImage) -> ImagePyramid {
         // Always add an alpha channel, if not present, to support our image operations.
+        // DynamicImage allows conversions, but we do it once here for performance reasons.
+        let original_has_alpha = original.color().has_alpha();
         let original = add_alpha_if_needed(original);
 
         let original_size = egui::Vec2::new(original.width() as f32, original.height() as f32);
@@ -49,6 +52,7 @@ impl ImagePyramid {
             original,
             aspect_ratio: original_size.x / original_size.y,
             original_size,
+            original_has_alpha,
         }
     }
 

--- a/src/image_pyramid.rs
+++ b/src/image_pyramid.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use eframe::egui;
 use log::{debug, trace};
 
-use crate::image::{add_alpha_if_needed, fit_image};
+use crate::image::{fit_image, to_rgba8};
 
 // Side lengths used for the image pyramid levels.
 // These shall correspond roughly to zoom levels w.r.t. original images.
@@ -25,8 +25,9 @@ impl ImagePyramid {
     pub fn new(original: image::DynamicImage) -> ImagePyramid {
         // Always add an alpha channel, if not present, to support our image operations.
         // DynamicImage allows conversions, but we do it once here for performance reasons.
+        // Use always RGBA8 internally.
         let original_has_alpha = original.color().has_alpha();
-        let original = add_alpha_if_needed(original);
+        let original = to_rgba8(original);
 
         let original_size = egui::Vec2::new(original.width() as f32, original.height() as f32);
         ImagePyramid {

--- a/src/lens.rs
+++ b/src/lens.rs
@@ -108,7 +108,10 @@ impl<'a> Lens<'a> {
         }
         let mut cropped_image = original_image.crop_imm(min_x, min_y, max_x - min_x, max_y - min_y);
         color_to_alpha(&mut cropped_image, map.color_to_alpha);
-        map.meta.value_interpretation.apply(&mut cropped_image);
+        map.meta.value_interpretation.apply(
+            &mut cropped_image,
+            texture_state.image_pyramid.original_has_alpha,
+        );
         let cropped_size = egui::vec2(cropped_image.width() as f32, cropped_image.height() as f32);
 
         let overlay_texture_handle = ui.ctx().load_texture(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,4 +16,5 @@ mod texture_request;
 mod texture_state;
 mod tiles;
 mod tiles_behavior;
+mod value_colormap;
 mod value_interpretation;

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -81,18 +81,8 @@ impl From<MetaYamlAnnotated> for Meta {
             resolution: meta_yaml.resolution,
             origin_xy: emath::Vec2::new(meta_yaml.origin[0], meta_yaml.origin[1]),
             origin_theta: emath::Rot2::from_angle(emath::normalized_angle(meta_yaml.origin[2])),
-            value_interpretation: ValueInterpretation::new(
-                meta_yaml.free_thresh,
-                meta_yaml.occupied_thresh,
-                meta_yaml.negate != 0,
-                meta_yaml.mode,
-            ),
-            original_value_interpretation: ValueInterpretation::new(
-                meta_yaml.free_thresh,
-                meta_yaml.occupied_thresh,
-                meta_yaml.negate != 0,
-                meta_yaml.mode,
-            ),
+            value_interpretation: ValueInterpretation::from_meta_yaml(meta_yaml),
+            original_value_interpretation: ValueInterpretation::from_meta_yaml(meta_yaml),
         }
     }
 }

--- a/src/texture_state.rs
+++ b/src/texture_state.rs
@@ -52,7 +52,7 @@ impl TextureState {
             );
             color_to_alpha(&mut image, request.color_to_alpha);
             if let Some(thresholding) = &request.thresholding {
-                thresholding.apply(&mut image);
+                thresholding.apply(&mut image, self.image_pyramid.original_has_alpha);
             }
             ui.ctx().load_texture(
                 request.client.clone(),
@@ -115,7 +115,7 @@ impl TextureState {
         }
         color_to_alpha(&mut cropped_image, request.uncropped.color_to_alpha);
         if let Some(thresholding) = &request.uncropped.thresholding {
-            thresholding.apply(&mut cropped_image);
+            thresholding.apply(&mut cropped_image, self.image_pyramid.original_has_alpha);
         }
 
         self.texture_handle = Some(ui.ctx().load_texture(

--- a/src/value_colormap.rs
+++ b/src/value_colormap.rs
@@ -1,0 +1,95 @@
+use image::Rgba;
+use serde::{Deserialize, Serialize};
+use lazy_static::lazy_static;
+
+/// Color mapping from cell values to RGBA colors.
+pub trait ValueColorMap {
+  fn map(&self, value: u8) -> Rgba<u8>;
+}
+
+/// Color map options. Includes the classic RViz colormaps.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub enum ColorMap {
+    #[default]
+    RvizMap,
+    RvizCostmap,
+    RvizRaw,
+}
+
+impl ColorMap {
+    pub fn get(&self) -> &dyn ValueColorMap {
+        match self {
+            ColorMap::RvizMap => &*RVIZ_MAP,
+            ColorMap::RvizCostmap => &*RVIZ_COSTMAP,
+            ColorMap::RvizRaw => &*RVIZ_RAW,
+        }
+    }
+}
+
+lazy_static!(
+  static ref RVIZ_MAP: RvizMapColors = RvizMapColors::new();
+  static ref RVIZ_COSTMAP: CostmapColors = CostmapColors::new();
+  static ref RVIZ_RAW: RvizRaw = RvizRaw;
+);
+
+/// Reimplementation of the ROS RViz "Map" occupancy grid colormap.
+struct RvizMapColors {
+    mapped: [Rgba<u8>; 256],
+}
+
+impl RvizMapColors {
+    fn new() -> Self {
+        let mut mapped: [Rgba<u8>; 256] = [Rgba([0, 0, 0, 255]); 256];
+        for i in 0..255 {
+            if (0..100).contains(&i) {
+                let x = 255 - (i as u8 * 255) / 100;
+                mapped[i] = Rgba([x, x, x, 255]);
+            }
+            if (101..127).contains(&i) {
+                mapped[i] = Rgba([0, 255, 0, 255]);
+            }
+            if (128..254).contains(&i) {
+                let x = (255 * (i as u8 - 128)) / (254 - 128);
+                mapped[i] = Rgba([255, x, 0, 255]);
+            }
+            mapped[i] = Rgba([112, 137, 134, 255]);
+        }
+        RvizMapColors { mapped }
+    }
+}
+
+impl ValueColorMap for RvizMapColors {
+    fn map(&self, value: u8) -> Rgba<u8> {
+        self.mapped[value as usize]
+    }
+}
+
+/// Reimplementation of the ROS RViz "Costmap" occupancy grid colormap.
+struct CostmapColors {
+  mapped: [Rgba<u8>; 256],
+}
+
+impl CostmapColors {
+  fn new() -> Self {
+      let mut mapped: [Rgba<u8>; 256] = [Rgba([0, 0, 0, 255]); 256];
+
+      // TODO
+
+      CostmapColors { mapped }
+  }
+}
+
+impl ValueColorMap for CostmapColors {
+  fn map(&self, value: u8) -> Rgba<u8> {
+      self.mapped[value as usize]
+  }
+}
+
+/// Reimplementation of the ROS RViz "Raw" occupancy grid colormap (no-op).
+struct RvizRaw;
+
+impl ValueColorMap for RvizRaw {
+  fn map(&self, value: u8) -> Rgba<u8> {
+      Rgba([value, value, value, 255])
+  }
+}

--- a/src/value_colormap.rs
+++ b/src/value_colormap.rs
@@ -11,9 +11,9 @@ pub trait ValueColorMap {
 /// Color map options. Includes the classic RViz colormaps.
 #[derive(Debug, Display, Default, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub enum ColorMap {
-    #[default]
     #[strum(to_string = "Raw")]
     Raw,
+    #[default]
     #[strum(to_string = "RViz \"Map\"")]
     RvizMap,
     #[strum(to_string = "RViz \"Costmap\"")]

--- a/src/value_colormap.rs
+++ b/src/value_colormap.rs
@@ -1,19 +1,25 @@
 use image::Rgba;
-use serde::{Deserialize, Serialize};
 use lazy_static::lazy_static;
+use serde::{Deserialize, Serialize};
+use strum_macros::Display;
 
 /// Color mapping from cell values to RGBA colors.
 pub trait ValueColorMap {
-  fn map(&self, value: u8) -> Rgba<u8>;
+    fn map(&self, value: u8) -> Rgba<u8>;
 }
 
 /// Color map options. Includes the classic RViz colormaps.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Display, Default, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub enum ColorMap {
     #[default]
+    #[strum(to_string = "RViz \"Map\"")]
     RvizMap,
+    #[strum(to_string = "RViz \"Costmap\"")]
     RvizCostmap,
+    #[strum(to_string = "RViz \"Raw\"")]
     RvizRaw,
+    #[strum(to_string = "Cool Costmap")]
+    CoolCostmap,
 }
 
 impl ColorMap {
@@ -22,15 +28,17 @@ impl ColorMap {
             ColorMap::RvizMap => &*RVIZ_MAP,
             ColorMap::RvizCostmap => &*RVIZ_COSTMAP,
             ColorMap::RvizRaw => &*RVIZ_RAW,
+            ColorMap::CoolCostmap => &*COOL_COSTMAP,
         }
     }
 }
 
-lazy_static!(
-  static ref RVIZ_MAP: RvizMapColors = RvizMapColors::new();
-  static ref RVIZ_COSTMAP: CostmapColors = CostmapColors::new();
-  static ref RVIZ_RAW: RvizRaw = RvizRaw;
-);
+lazy_static! {
+    static ref RVIZ_MAP: RvizMapColors = RvizMapColors::new();
+    static ref RVIZ_COSTMAP: CostmapColors = CostmapColors::new();
+    static ref RVIZ_RAW: RvizRaw = RvizRaw;
+    static ref COOL_COSTMAP: CoolCostmapColors = CoolCostmapColors::new();
+}
 
 /// Reimplementation of the ROS RViz "Map" occupancy grid colormap.
 struct RvizMapColors {
@@ -40,19 +48,18 @@ struct RvizMapColors {
 impl RvizMapColors {
     fn new() -> Self {
         let mut mapped: [Rgba<u8>; 256] = [Rgba([0, 0, 0, 255]); 256];
-        for i in 0..255 {
-            if (0..100).contains(&i) {
-                let x = 255 - (i as u8 * 255) / 100;
+        for i in 0..256 {
+            if (0..101).contains(&i) {
+                let x = (255. - (i as f32 * 255.) / 100.) as u8;
                 mapped[i] = Rgba([x, x, x, 255]);
-            }
-            if (101..127).contains(&i) {
+            } else if (101..128).contains(&i) {
                 mapped[i] = Rgba([0, 255, 0, 255]);
-            }
-            if (128..254).contains(&i) {
-                let x = (255 * (i as u8 - 128)) / (254 - 128);
+            } else if (128..255).contains(&i) {
+                let x = ((255. * (i as f32 - 128.)) / (254. - 128.)) as u8;
                 mapped[i] = Rgba([255, x, 0, 255]);
+            } else {
+                mapped[i] = Rgba([112, 137, 134, 255]);
             }
-            mapped[i] = Rgba([112, 137, 134, 255]);
         }
         RvizMapColors { mapped }
     }
@@ -66,30 +73,124 @@ impl ValueColorMap for RvizMapColors {
 
 /// Reimplementation of the ROS RViz "Costmap" occupancy grid colormap.
 struct CostmapColors {
-  mapped: [Rgba<u8>; 256],
+    mapped: [Rgba<u8>; 256],
 }
 
 impl CostmapColors {
-  fn new() -> Self {
-      let mut mapped: [Rgba<u8>; 256] = [Rgba([0, 0, 0, 255]); 256];
-
-      // TODO
-
-      CostmapColors { mapped }
-  }
+    fn new() -> Self {
+        let mut mapped: [Rgba<u8>; 256] = [Rgba([0, 0, 0, 255]); 256];
+        for i in 0..256 {
+            if i == 0 {
+                mapped[i] = Rgba([0, 0, 0, 0]);
+            } else if (1..99).contains(&i) {
+                let x = (i as f32 * 255. / 100.) as u8;
+                mapped[i] = Rgba([x, 0, 255 - x, 255]);
+            } else if i == 99 {
+                mapped[i] = Rgba([0, 255, 255, 255]);
+            } else if i == 100 {
+                mapped[i] = Rgba([255, 0, 255, 255]);
+            } else if (101..128).contains(&i) {
+                mapped[i] = Rgba([0, 255, 0, 255]);
+            } else if (128..255).contains(&i) {
+                let x = ((255. * (i as f32 - 128.)) / (254. - 128.)) as u8;
+                mapped[i] = Rgba([255, x, 0, 255]);
+            } else {
+                mapped[i] = Rgba([112, 137, 134, 255]);
+            }
+        }
+        CostmapColors { mapped }
+    }
 }
 
 impl ValueColorMap for CostmapColors {
-  fn map(&self, value: u8) -> Rgba<u8> {
-      self.mapped[value as usize]
-  }
+    fn map(&self, value: u8) -> Rgba<u8> {
+        self.mapped[value as usize]
+    }
 }
 
 /// Reimplementation of the ROS RViz "Raw" occupancy grid colormap (no-op).
 struct RvizRaw;
 
 impl ValueColorMap for RvizRaw {
-  fn map(&self, value: u8) -> Rgba<u8> {
-      Rgba([value, value, value, 255])
-  }
+    fn map(&self, value: u8) -> Rgba<u8> {
+        Rgba([value, value, value, 255])
+    }
+}
+
+/// An alternative costmap color map with less screaming colors.
+pub struct CoolCostmapColors {
+    mapped: [Rgba<u8>; 256],
+}
+
+impl CoolCostmapColors {
+    pub fn new() -> Self {
+        let mut mapped: [Rgba<u8>; 256] = [Rgba([0, 0, 0, 255]); 256];
+        for i in 0..256 {
+            if i == 0 {
+                mapped[i] = Rgba([0, 0, 0, 0]);
+            } else if (1..99).contains(&i) {
+                let r = (38. + (i as f32 * 129.) / 100.) as u8;
+                let g = (55. + (i as f32 * 171.) / 100.) as u8;
+                let b = (59. + (i as f32 * 134.) / 100.) as u8;
+                mapped[i] = Rgba([r, g, b, 255]);
+            } else if i == 99 {
+                mapped[i] = Rgba([38, 55, 59, 255]);
+            } else if i == 100 {
+                mapped[i] = Rgba([255, 252, 93, 255]);
+            } else if (101..128).contains(&i) {
+                mapped[i] = Rgba([0, 255, 0, 255]);
+            } else if (128..255).contains(&i) {
+                let x = ((255. * (i as f32 - 128.)) / (254. - 128.)) as u8;
+                mapped[i] = Rgba([255, x, 0, 255]);
+            } else {
+                mapped[i] = Rgba([112, 137, 134, 255]);
+            }
+        }
+        CoolCostmapColors { mapped }
+    }
+}
+
+impl ValueColorMap for CoolCostmapColors {
+    fn map(&self, value: u8) -> Rgba<u8> {
+        self.mapped[value as usize]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rviz_map_colors() {
+        let palette = RvizMapColors::new();
+        assert_eq!(palette.map(0), Rgba([255, 255, 255, 255]));
+        print!("{:?}", palette.mapped[100]);
+        assert_eq!(palette.map(100), Rgba([0, 0, 0, 255]));
+        assert_eq!(palette.map(101), Rgba([0, 255, 0, 255]));
+        assert_eq!(palette.map(128), Rgba([255, 0, 0, 255]));
+        assert_eq!(palette.map(254), Rgba([255, 255, 0, 255]));
+        assert_eq!(palette.map(255), Rgba([112, 137, 134, 255]));
+    }
+
+    #[test]
+    fn test_costmap_colors() {
+        let palette = CostmapColors::new();
+        assert_eq!(palette.map(0), Rgba([0, 0, 0, 0]));
+        assert_eq!(palette.map(1), Rgba([2, 0, 253, 255]));
+        assert_eq!(palette.map(99), Rgba([0, 255, 255, 255]));
+        assert_eq!(palette.map(100), Rgba([255, 0, 255, 255]));
+        assert_eq!(palette.map(101), Rgba([0, 255, 0, 255]));
+        assert_eq!(palette.map(128), Rgba([255, 0, 0, 255]));
+        assert_eq!(palette.map(234), Rgba([255, 214, 0, 255]));
+        assert_eq!(palette.map(254), Rgba([255, 255, 0, 255]));
+        assert_eq!(palette.map(255), Rgba([112, 137, 134, 255]));
+    }
+
+    #[test]
+    fn test_rviz_raw_colors() {
+        let palette = RvizRaw;
+        assert_eq!(palette.map(0), Rgba([0, 0, 0, 255]));
+        assert_eq!(palette.map(100), Rgba([100, 100, 100, 255]));
+        assert_eq!(palette.map(255), Rgba([255, 255, 255, 255]));
+    }
 }

--- a/src/value_colormap.rs
+++ b/src/value_colormap.rs
@@ -164,7 +164,6 @@ mod tests {
     fn test_rviz_map_colors() {
         let palette = RvizMapColors::new();
         assert_eq!(palette.map(0), Rgba([255, 255, 255, 255]));
-        print!("{:?}", palette.mapped[100]);
         assert_eq!(palette.map(100), Rgba([0, 0, 0, 255]));
         assert_eq!(palette.map(101), Rgba([0, 255, 0, 255]));
         assert_eq!(palette.map(128), Rgba([255, 0, 0, 255]));

--- a/src/value_colormap.rs
+++ b/src/value_colormap.rs
@@ -12,12 +12,12 @@ pub trait ValueColorMap {
 #[derive(Debug, Display, Default, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub enum ColorMap {
     #[default]
+    #[strum(to_string = "Raw")]
+    Raw,
     #[strum(to_string = "RViz \"Map\"")]
     RvizMap,
     #[strum(to_string = "RViz \"Costmap\"")]
     RvizCostmap,
-    #[strum(to_string = "RViz \"Raw\"")]
-    RvizRaw,
     #[strum(to_string = "Cool Costmap")]
     CoolCostmap,
 }
@@ -27,7 +27,7 @@ impl ColorMap {
         match self {
             ColorMap::RvizMap => &*RVIZ_MAP,
             ColorMap::RvizCostmap => &*RVIZ_COSTMAP,
-            ColorMap::RvizRaw => &*RVIZ_RAW,
+            ColorMap::Raw => &*RAW,
             ColorMap::CoolCostmap => &*COOL_COSTMAP,
         }
     }
@@ -36,7 +36,7 @@ impl ColorMap {
 lazy_static! {
     static ref RVIZ_MAP: RvizMapColors = RvizMapColors::new();
     static ref RVIZ_COSTMAP: CostmapColors = CostmapColors::new();
-    static ref RVIZ_RAW: RvizRaw = RvizRaw;
+    static ref RAW: Raw = Raw;
     static ref COOL_COSTMAP: CoolCostmapColors = CoolCostmapColors::new();
 }
 
@@ -108,10 +108,10 @@ impl ValueColorMap for CostmapColors {
     }
 }
 
-/// Reimplementation of the ROS RViz "Raw" occupancy grid colormap (no-op).
-struct RvizRaw;
+/// "Raw" occupancy grid colormap (no-op).
+struct Raw;
 
-impl ValueColorMap for RvizRaw {
+impl ValueColorMap for Raw {
     fn map(&self, value: u8) -> Rgba<u8> {
         Rgba([value, value, value, 255])
     }
@@ -188,7 +188,7 @@ mod tests {
 
     #[test]
     fn test_rviz_raw_colors() {
-        let palette = RvizRaw;
+        let palette = Raw;
         assert_eq!(palette.map(0), Rgba([0, 0, 0, 255]));
         assert_eq!(palette.map(100), Rgba([100, 100, 100, 255]));
         assert_eq!(palette.map(255), Rgba([255, 255, 255, 255]));

--- a/src/value_interpretation.rs
+++ b/src/value_interpretation.rs
@@ -14,6 +14,7 @@ const MAP_SERVER_OCCUPIED_DEFAULT: f32 = 0.65;
 use image::{DynamicImage, Rgba};
 use imageproc::{integral_image::ArrayData, map::map_colors_mut};
 
+use crate::meta::MetaYaml;
 use crate::value_colormap::ColorMap;
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
@@ -69,9 +70,23 @@ impl ValueInterpretation {
         }
     }
 
+    pub fn from_meta_yaml(meta: &MetaYaml) -> Self {
+        ValueInterpretation::new(
+            meta.free_thresh,
+            meta.occupied_thresh,
+            meta.negate != 0,
+            meta.mode,
+        )
+    }
+
     /// Allows to mimic the wonderful undocumented behaviors of map_server.
     pub fn with_quirks(mut self, quirks: Quirks) -> Self {
         self.quirks = quirks;
+        self
+    }
+
+    pub fn with_colormap(mut self, colormap: ColorMap) -> Self {
+        self.colormap = colormap;
         self
     }
 

--- a/src/value_interpretation.rs
+++ b/src/value_interpretation.rs
@@ -40,6 +40,7 @@ pub struct ValueInterpretation {
     pub negate: bool,
     pub mode: Mode,
     pub quirks: Quirks,
+    #[serde(default)]
     pub colormap: ColorMap,
 }
 

--- a/src/value_interpretation.rs
+++ b/src/value_interpretation.rs
@@ -93,9 +93,7 @@ impl ValueInterpretation {
         self
     }
 
-    /// Modifies the image according to the value interpretation.
-    /// Note that the output needs a color map for visualization.
-    /// Without color map, the image corresponds to the "raw" display of RViz.
+    /// Modifies the image according to the value interpretation and colormap.
     ///
     /// The "original_has_alpha" parameter is used to determine if the source
     /// image had an alpha channel. This is necessary for some implementation quirks.

--- a/src/value_interpretation.rs
+++ b/src/value_interpretation.rs
@@ -194,8 +194,9 @@ mod tests {
     }
 
     #[test]
-    fn trinary() {
-        let thresholding = ValueInterpretation::new(0.196, 0.65, false, Some(Mode::Trinary));
+    fn trinary_wiki() {
+        let thresholding = ValueInterpretation::new(0.196, 0.65, false, Some(Mode::Trinary))
+            .with_quirks(Quirks::Ros1Wiki);
         let mut img = DynamicImage::new_rgba8(1, 1);
 
         img.put_pixel(0, 0, Rgba([128, 128, 128, 255]));
@@ -221,8 +222,9 @@ mod tests {
     }
 
     #[test]
-    fn scale() {
-        let thresholding = ValueInterpretation::new(0.196, 0.65, false, Some(Mode::Scale));
+    fn scale_wiki() {
+        let thresholding = ValueInterpretation::new(0.196, 0.65, false, Some(Mode::Scale))
+            .with_quirks(Quirks::Ros1Wiki);
         let mut img = DynamicImage::new_rgba8(1, 1);
 
         img.put_pixel(0, 0, Rgba([128, 128, 128, 255]));

--- a/src/value_interpretation.rs
+++ b/src/value_interpretation.rs
@@ -14,6 +14,8 @@ const MAP_SERVER_OCCUPIED_DEFAULT: f32 = 0.65;
 use image::{DynamicImage, Rgba};
 use imageproc::{integral_image::ArrayData, map::map_colors_mut};
 
+use crate::value_colormap::ColorMap;
+
 #[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Mode {
@@ -38,6 +40,7 @@ pub struct ValueInterpretation {
     pub negate: bool,
     pub mode: Mode,
     pub quirks: Quirks,
+    pub colormap: ColorMap,
 }
 
 impl Default for ValueInterpretation {
@@ -48,6 +51,7 @@ impl Default for ValueInterpretation {
             negate: false,
             mode: Mode::default(),
             quirks: Quirks::default(),
+            colormap: ColorMap::default(),
         }
     }
 }
@@ -60,6 +64,7 @@ impl ValueInterpretation {
             negate,
             mode: mode.unwrap_or_default(),
             quirks: Quirks::default(),
+            colormap: ColorMap::default(),
         }
     }
 
@@ -76,7 +81,7 @@ impl ValueInterpretation {
         match self.mode {
             Mode::Raw => {}
             Mode::Trinary | Mode::Scale => {
-                map_colors_mut(img, |c| self.interpret(&c));
+                map_colors_mut(img, |c| self.colormap.get().map(self.interpret(&c)[0]));
             }
         }
     }


### PR DESCRIPTION
Go from intermediate occupancy grid message like state (PR #11)
to something meaningful on the display.

Relates to: #7