### PR TITLE
Avoid accidental grid movement when dragging widgets

### DIFF
--- a/src/app_impl/central_panel.rs
+++ b/src/app_impl/central_panel.rs
@@ -85,9 +85,13 @@ impl AppState {
                     ui.ctx().set_cursor_icon(egui::CursorIcon::Default);
                 }
             }
+
+            // Grid area is not a widget. Avoid accidental grid dragging when
+            // any widget intersecting it is being dragged (e.g. a lens window).
+            let dragging_others = ui.ctx().dragged_id().is_some();
             ui.input(|i| {
                 clicked = i.pointer.primary_released();
-                if i.pointer.primary_down() {
+                if i.pointer.primary_down() && !dragging_others {
                     // Scaled because meters are expected for drag().
                     options.drag(i.pointer.delta() / options.scale);
                 }


### PR DESCRIPTION
Catch interactions with widgets, e.g. resizing or moving a lens window, to avoid movements of the grid area when the pointer touches it while the widget is modified.

Relates to: #44