### PR TITLE
Add tracing for frame update durations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1373,6 +1373,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "egui_plot"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1794c66fb727dac28dffed2e4b548e5118d1cccc331d368a35411d68725dde71"
+dependencies = [
+ "ahash",
+ "egui",
+ "emath",
+]
+
+[[package]]
 name = "egui_tiles"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2418,7 +2429,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2515,6 +2526,7 @@ dependencies = [
  "egui_dnd",
  "egui_extras",
  "egui_kittest",
+ "egui_plot",
  "egui_tiles",
  "env_logger",
  "fast_image_resize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ egui_extras = { version = "0.31.0", features = ["all_loaders", "serde"] }
 egui_dnd = "0.12.0"
 egui-file-dialog = "0.9.0"
 egui_kittest = { version = "0.31.0", features = ["wgpu", "snapshot", "eframe"] }
+egui_plot = "0.31.0"
 egui_tiles = "0.12.0"
 env_logger = "0.11.5"
 fast_image_resize = { version = "5.1.1", features = ["image"] }

--- a/src/app_impl/debug_window.rs
+++ b/src/app_impl/debug_window.rs
@@ -21,6 +21,16 @@ impl AppState {
                     ui.collapsing("Memory", |ui| {
                         ctx.memory_ui(ui);
                     });
+                    egui::CollapsingHeader::new("Timing")
+                        .default_open(true)
+                        .show(ui, |ui| {
+                            ui.label(format!(
+                                "Last {} {} durations in seconds",
+                                self.tracing.buffer_size(),
+                                self.tracing.name.as_str()
+                            ));
+                            self.tracing.plot(ui);
+                        });
                     egui::CollapsingHeader::new("Textures")
                         .default_open(true)
                         .show(ui, |ui| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ mod texture_request;
 mod texture_state;
 mod tiles;
 mod tiles_behavior;
+mod tracing;
 pub mod value_colormap;
 pub mod value_interpretation;
 

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -1,0 +1,91 @@
+use std::collections::VecDeque;
+use std::time;
+
+use eframe::egui;
+use egui_plot::{Line, Plot, PlotPoints};
+
+#[cfg(target_arch = "wasm32")]
+use web_sys;
+
+/// Monotonic clock timestamp for native builds.
+#[cfg(not(target_arch = "wasm32"))]
+type TimeInstant = time::Instant;
+
+/// Monotonic web_sys millisecond timestamp, with up to microsecond resolution.
+/// https://developer.mozilla.org/en-US/docs/Web/API/Performance/now
+#[cfg(target_arch = "wasm32")]
+type TimeInstant = f64;
+
+fn now() -> TimeInstant {
+    #[cfg(not(target_arch = "wasm32"))]
+    return time::Instant::now();
+
+    #[cfg(target_arch = "wasm32")]
+    web_sys::window()
+        .expect("no window")
+        .performance()
+        .expect("no performance")
+        .now()
+}
+
+/// Tracing tool for measuring durations, buffering them, plotting etc.
+/// wasm compatible, not thread-safe.
+#[derive(Default)]
+pub struct Tracing {
+    pub name: String,
+    current: Option<TimeInstant>,
+    max_buffer_size: usize,
+    buffer: VecDeque<time::Duration>,
+}
+
+impl Tracing {
+    pub fn new(name: &str, max_buffer_size: usize) -> Tracing {
+        Tracing {
+            name: name.into(),
+            current: None,
+            max_buffer_size,
+            buffer: VecDeque::with_capacity(max_buffer_size),
+        }
+    }
+
+    pub fn buffer_size(&self) -> usize {
+        self.buffer.len()
+    }
+
+    /// Start a new measurement.
+    pub fn start(&mut self) {
+        self.current = Some(now());
+    }
+
+    /// Measures and stores the duration since the last start() in the buffer.
+    /// Requires start() before.
+    pub fn measure(&mut self) {
+        if self.buffer.len() == self.max_buffer_size {
+            self.buffer.pop_front();
+        }
+        let current = self.current.expect("missing start()");
+
+        #[cfg(not(target_arch = "wasm32"))]
+        self.buffer.push_back(current.elapsed());
+
+        #[cfg(target_arch = "wasm32")]
+        self.buffer.push_back(time::Duration::from_micros(
+            ((now() - current) * 1e3) as u64,
+        ));
+    }
+
+    /// Plots the buffered measurements as f64 seconds.
+    pub fn plot(&self, ui: &mut egui::Ui) {
+        let points: PlotPoints = (0..self.buffer_size())
+            .map(|i| {
+                [
+                    i as f64,
+                    self.buffer.get(i).expect("missing duration").as_secs_f64(),
+                ]
+            })
+            .collect();
+        Plot::new(self.name.as_str())
+            .view_aspect(2.0)
+            .show(ui, |plot_ui| plot_ui.line(Line::new(points)));
+    }
+}


### PR DESCRIPTION
Measures App::update() times that can be viewed in a plot using the debug window (debug or trace log level).