### PR TITLE
Don't serialize pose edit options

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -92,6 +92,7 @@ pub struct AppOptions {
     pub lens: LensOptions,
     pub grid: GridOptions,
     pub tint_settings: TintOptions,
+    #[serde(skip)]
     pub pose_edit: PoseEditOptions,
     pub active_movable: ActiveMovable,
     #[serde(skip)]

--- a/src/app_impl/pose_edit.rs
+++ b/src/app_impl/pose_edit.rs
@@ -1,19 +1,16 @@
 use std::f32::consts::PI;
 
 use eframe::egui;
-use serde::{Deserialize, Serialize};
 
 use crate::app::{ActiveMovable, AppState};
 use crate::app_impl::constants::SPACE;
 use crate::movable::MovableAmounts;
 
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Default)]
 pub struct PoseEditOptions {
-    #[serde(skip_serializing, skip_deserializing)]
     pub selected_map: String,
     pub edit_root_frame: bool,
     pub edit_map_frame: bool,
-    #[serde(skip)]
     pub movable_amounts: MovableAmounts,
 }
 


### PR DESCRIPTION
Makes no sense to serialize, and could cause issues when reloading. Active text edits via edit_{root, map}_frame block the keybindings and aren't obvious to spot when starting into a new session.