### PR TITLE
Remember value interpretation flag correctly

### DIFF
--- a/src/app_impl/tint_settings.rs
+++ b/src/app_impl/tint_settings.rs
@@ -187,6 +187,9 @@ fn pick(
         ui.end_row();
         pick_value_interpretation(ui, value_interpretation);
     }
+    // Remember when the user explicitly selects/deselect value interpretation.
+    // This way it's picked up correctly when saved to a session and then reloaded.
+    value_interpretation.explicit_mode = *edit_value_interpretation;
 }
 
 fn pick_color_to_alpha(ui: &mut egui::Ui, color_to_alpha: &mut Option<egui::Color32>) {

--- a/src/value_interpretation.rs
+++ b/src/value_interpretation.rs
@@ -54,6 +54,9 @@ pub struct ValueInterpretation {
     pub occupied: f32,
     pub negate: bool,
     pub mode: Mode,
+    /// Whether the interpretation is set explicitly,
+    /// either by the optional `mode` field in the YAML
+    /// or by the user through the UI.
     #[serde(default)]
     pub explicit_mode: bool,
     pub quirks: Quirks,


### PR DESCRIPTION
Mark it as explicitly set when changed through the UI, so it is saved and reloaded as active in session files.