### PR TITLE
Use uncropped textures below a size threshold

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -22,6 +22,7 @@ use crate::draw_order::DrawOrder;
 use crate::map_state::MapState;
 use crate::meta::Meta;
 use crate::persistence::{save_app_options, PersistenceOptions};
+use crate::render_options::default_crop_threshold;
 use crate::tiles::Tiles;
 use crate::tracing::Tracing;
 
@@ -149,10 +150,29 @@ pub struct SessionData {
     pub(crate) demo_button_image_handle: Option<egui::TextureHandle>,
 }
 
+/// Options that should not need to be changed by the (average) user.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AdvancedOptions {
+    /// Threshold for cropping large textures in the main grid.
+    /// Too low values cause unnecessary cropping (CPU overhead),
+    /// too high values lead to too high texture memory usage.
+    #[serde(default = "default_crop_threshold")]
+    pub grid_crop_threshold: u32,
+}
+
+impl Default for AdvancedOptions {
+    fn default() -> Self {
+        Self {
+            grid_crop_threshold: default_crop_threshold(),
+        }
+    }
+}
+
 /// Main application state, implements the `eframe::App` trait.
 #[derive(Default)]
 pub struct AppState {
     pub options: AppOptions,
+    pub advanced: AdvancedOptions,
     pub build_info: String,
     pub data: SessionData,
     pub status: StatusInfo,

--- a/src/app_impl/central_panel.rs
+++ b/src/app_impl/central_panel.rs
@@ -103,7 +103,9 @@ impl AppState {
             });
         }
 
-        let grid = Grid::new(ui, "main_grid", options.scale).with_origin_offset(options.offset);
+        let grid = Grid::new(ui, "main_grid", options.scale)
+            .with_origin_offset(options.offset)
+            .with_texture_crop_threshold(self.advanced.grid_crop_threshold);
         grid.show_maps(ui, &mut self.data.maps, options, &self.data.draw_order);
         if options.lines_visible {
             grid.draw(ui, options, LineType::Main);
@@ -211,7 +213,10 @@ impl AppState {
                     self.options.canvas_settings.background_color,
                 );
                 // Show the lens grid.
-                let mini_grid = Grid::new(ui, id, grid_lens_scale).centered_at(center_pos);
+                // Crop threshold is set to 0 to always crop the textures in a lens.
+                let mini_grid = Grid::new(ui, id, grid_lens_scale)
+                    .centered_at(center_pos)
+                    .with_texture_crop_threshold(0);
                 mini_grid.show_maps(ui, &mut self.data.maps, options, &self.data.draw_order);
                 if options.lines_visible {
                     mini_grid.draw(ui, options, LineType::Main);

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -16,6 +16,7 @@ pub struct Grid {
     pub points_per_meter: f32,
     pub origin_in_points: egui::Pos2, // Location of the origin in point coordinates.
     pub left_offset: egui::Vec2,
+    texture_crop_threshold: u32,
 }
 
 // Relations of a RHS metric coordinate map to the LHS point coordinate grid.
@@ -84,6 +85,7 @@ impl Grid {
             points_per_meter,
             origin_in_points: (available_size / 2.).to_pos2() + ui_offset,
             left_offset,
+            texture_crop_threshold: 0,
         }
     }
 
@@ -95,6 +97,11 @@ impl Grid {
     pub fn centered_at(self, metric_pos: egui::Pos2) -> Self {
         let offset = flip(-metric_pos.to_vec2()) * self.points_per_meter;
         self.with_origin_offset(offset)
+    }
+
+    pub fn with_texture_crop_threshold(mut self, threshold: u32) -> Self {
+        self.texture_crop_threshold = threshold;
+        self
     }
 
     pub fn to_metric(&self, point: &egui::Pos2) -> egui::Pos2 {
@@ -138,6 +145,7 @@ impl Grid {
             relation.ulc_to_origin_in_points_translated - relation.ulc_to_origin_in_points,
             relation.ulc_to_origin_in_points,
             relation.points_per_cell,
+            self.texture_crop_threshold,
         );
         map.get_or_create_texture_state(self.name.as_str())
             .crop_and_put(ui, &request);

--- a/src/image_pyramid.rs
+++ b/src/image_pyramid.rs
@@ -8,7 +8,7 @@ use crate::image::{fit_image, to_rgba8};
 
 // Side lengths used for the image pyramid levels.
 // These shall correspond roughly to zoom levels w.r.t. original images.
-const SIZES: [u32; 7] = [8000, 6000, 4000, 2000, 1000, 500, 250];
+const SIZES: [u32; 5] = [8000, 4000, 2000, 1000, 500];
 
 // Stores downscaled versions of an image for discrete sizes.
 // Intended for efficient on-screen rendering of images at different zoom levels.

--- a/src/render_options.rs
+++ b/src/render_options.rs
@@ -1,6 +1,11 @@
 use eframe::egui;
 use serde::{Deserialize, Serialize};
 
+/// Textures above this size should be cropped.
+pub const fn default_crop_threshold() -> u32 {
+    4000
+}
+
 /// Options for image rendering.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub enum TextureFilter {

--- a/tests/snapshots/aligned_view.png
+++ b/tests/snapshots/aligned_view.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3b49ce27eec9fc27a80476dff3de1dbd1ba78bd5a93320afd844013b10ecd24d
-size 71437
+oid sha256:4813b9053074aca7acc08ca7cc9dd884798c551ae9ff94bf37feed644cf70055
+size 71429

--- a/tests/snapshots/google_cartographer_example.png
+++ b/tests/snapshots/google_cartographer_example.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:edd71efb0649829e9e667b0402f88463e8ca1804d6502f7667f1976dd79484ef
-size 292500
+oid sha256:b1ac0925049381a4feb77e4cbad743e50160a335bacaa8a009a32aeab09676d8
+size 291197

--- a/tests/snapshots/measurement.png
+++ b/tests/snapshots/measurement.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:17c3be3f6a67a9255936c87fb3fb563c47d200fca93b3a7474b0b506e859b986
-size 85220
+oid sha256:b5fd07caf3f5166df17df0575d3ef30cf3c5d05a3d38bb417929a90c9e008cf3
+size 85206


### PR DESCRIPTION
The cropping is only needed and efficient for large images at high zoom / lens.

Textures up to 4000x4000px now just stay uncropped in the VRAM, saving CPU when dragging or zooming.

Relates to #58 