### PR TITLE
Exclude global tint/blend settings from saved options

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -92,6 +92,7 @@ pub struct AppOptions {
     pub view_mode: ViewMode,
     pub lens: LensOptions,
     pub grid: GridOptions,
+    #[serde(skip)]
     pub tint_settings: TintOptions,
     #[serde(skip)]
     pub pose_edit: PoseEditOptions,
@@ -201,6 +202,9 @@ impl AppState {
         }
         for map in state.data.maps.values_mut() {
             map.tint = Some(state.options.tint_settings.tint_for_all);
+            if let Some(color_to_alpha) = state.options.tint_settings.color_to_alpha_for_all {
+                map.color_to_alpha = Some(color_to_alpha);
+            }
         }
 
         #[cfg(not(target_arch = "wasm32"))]

--- a/src/app_impl/tint_settings.rs
+++ b/src/app_impl/tint_settings.rs
@@ -14,18 +14,16 @@ use crate::texture_request::NO_TINT;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TintOptions {
-    #[serde(skip)]
+    // Note that these options are for operations on _all_ maps,
+    // and thus are skipped in the options autosave (see AppOptions).
+    // The equivalent options for individual maps are in MapState (and get serialized in sessions).
     pub active_tint_selection: Option<String>,
     pub tint_for_all: egui::Color32,
     pub edit_color_to_alpha: bool,
     pub color_to_alpha_for_all: Option<egui::Color32>,
-    #[serde(default, skip)]
     pub use_value_interpretation_for_all: bool,
-    #[serde(default, skip)]
     pub value_interpretation_for_all: ValueInterpretation,
-    #[serde(default, skip)]
     pub colormap_for_all: ColorMap,
-    #[serde(default)]
     pub texture_filter_for_all: TextureFilter,
 }
 
@@ -120,6 +118,7 @@ impl AppState {
             }
         } else if let Some(map) = self.data.maps.get_mut(selected) {
             let tint = map.tint.get_or_insert(NO_TINT);
+            let mut edit_color_to_alpha = map.color_to_alpha.is_some();
             let color_to_alpha = &mut map.color_to_alpha;
 
             if reset {
@@ -132,7 +131,7 @@ impl AppState {
                 reset,
                 tint,
                 color_to_alpha,
-                &mut self.options.tint_settings.edit_color_to_alpha,
+                &mut edit_color_to_alpha,
                 &mut map.use_value_interpretation,
                 &mut map.meta.value_interpretation,
                 &mut map.texture_filter,


### PR DESCRIPTION
Since they affect all maps, they can mess up blend settings of individual maps that are loaded from session files.

Also fixes a bug that falsely set the "edit color to alpha" checkbox for individual maps and adds a CLI option to set the color-to-alpha for all.