### PR TITLE
Show only file names by default

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -78,6 +78,11 @@ pub struct CollapsedState {
     pub tool_settings: bool,
 }
 
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct DisplayOptions {
+    pub show_full_paths: bool,
+}
+
 /// Contains all configurable options of the application.
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct AppOptions {
@@ -103,6 +108,8 @@ pub struct AppOptions {
     pub active_tool: ActiveTool,
     #[serde(default)]
     pub collapsed: CollapsedState,
+    #[serde(default)]
+    pub display: DisplayOptions,
 }
 
 impl AppOptions {

--- a/src/app_impl/app_settings.rs
+++ b/src/app_impl/app_settings.rs
@@ -23,5 +23,12 @@ impl AppState {
                 .weak()
                 .italics(),
         );
+
+        ui.end_row();
+        ui.label("Show full paths").on_hover_text(
+            "Show full absolute file paths in the UI.\n\
+            If unchecked, only the file name is shown.",
+        );
+        ui.checkbox(&mut self.options.display.show_full_paths, "");
     }
 }

--- a/src/app_impl/menu_panel.rs
+++ b/src/app_impl/menu_panel.rs
@@ -2,6 +2,7 @@ use eframe::egui;
 
 use crate::app::AppState;
 use crate::app_impl::constants::SPACE;
+use crate::app_impl::ui_helpers::display_path;
 
 impl AppState {
     pub(crate) fn menu_panel(&mut self, ui: &mut egui::Ui) {
@@ -43,7 +44,14 @@ impl AppState {
             .striped(true)
             .show(ui, |ui| {
                 for (name, map) in &mut self.data.maps {
-                    if ui.checkbox(&mut map.visible, name).changed() {
+                    if ui
+                        .checkbox(
+                            &mut map.visible,
+                            display_path(name, self.options.display.show_full_paths),
+                        )
+                        .on_hover_text(name)
+                        .changed()
+                    {
                         self.tile_manager.set_visible(name, map.visible);
                     }
                     if ui.button("🗑").on_hover_text("Delete Map").clicked() {
@@ -96,10 +104,13 @@ impl AppState {
                 ui.horizontal(|ui| {
                     ui.toggle_value(&mut self.status.draw_order_edit_active, "⬆⬇")
                         .on_hover_text("Click to view and edit the draw order via drag and drop.");
-                    if !self.status.draw_order_edit_active {
+                    if !self.status.draw_order_edit_active && !self.data.maps.is_empty() {
                         ui.separator();
                         self.deselect_toggle(ui);
                     }
+                    ui.separator();
+                    ui.toggle_value(&mut self.options.display.show_full_paths, "/../..")
+                        .on_hover_text("Show full paths instead of just the file name.");
                 });
                 if self.status.draw_order_edit_active {
                     self.data.draw_order.ui(ui);

--- a/src/app_impl/pose_edit.rs
+++ b/src/app_impl/pose_edit.rs
@@ -4,6 +4,7 @@ use eframe::egui;
 
 use crate::app::{ActiveMovable, AppState};
 use crate::app_impl::constants::SPACE;
+use crate::app_impl::ui_helpers::display_path;
 use crate::movable::MovableAmounts;
 
 #[derive(Debug, Default)]
@@ -20,14 +21,18 @@ impl AppState {
         // Waiting for: https://github.com/emilk/egui/discussions/1829
         egui::ScrollArea::horizontal().show(ui, |ui| {
             egui::ComboBox::from_label("")
-                .selected_text(self.options.pose_edit.selected_map.clone())
+                .selected_text(display_path(
+                    &self.options.pose_edit.selected_map,
+                    self.options.display.show_full_paths,
+                ))
                 .show_ui(ui, |ui| {
                     for name in self.data.maps.keys() {
                         ui.selectable_value(
                             &mut self.options.pose_edit.selected_map,
                             name.clone(),
-                            name,
-                        );
+                            display_path(name, self.options.display.show_full_paths),
+                        )
+                        .on_hover_text(name);
                     }
                 });
         });
@@ -194,8 +199,8 @@ impl AppState {
                         continue;
                     }
                     if ui
-                        .button(name)
-                        .on_hover_text("Click to copy the map pose also to this other map.")
+                        .button(display_path(name, self.options.display.show_full_paths))
+                        .on_hover_text(format!("Click to copy the map pose also to {}.", name))
                         .clicked()
                     {
                         selected_maps.push(name.clone());

--- a/src/app_impl/tint_settings.rs
+++ b/src/app_impl/tint_settings.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::app::AppState;
 use crate::app_impl::constants::SPACE;
-use crate::app_impl::ui_helpers::section_heading;
+use crate::app_impl::ui_helpers::{display_path, section_heading};
 use crate::render_options::TextureFilter;
 use crate::value_colormap::ColorMap;
 use crate::value_interpretation::{Mode, Quirks, ValueInterpretation};
@@ -61,11 +61,16 @@ impl AppState {
         // Waiting for: https://github.com/emilk/egui/discussions/1829
         egui::ScrollArea::horizontal().show(ui, |ui| {
             egui::ComboBox::from_label("")
-                .selected_text(selected.to_string())
+                .selected_text(display_path(selected, self.options.display.show_full_paths))
                 .show_ui(ui, |ui| {
                     ui.selectable_value(selected, all_key.clone(), &all_key);
                     for name in self.data.maps.keys() {
-                        ui.selectable_value(selected, name.to_string(), name);
+                        ui.selectable_value(
+                            selected,
+                            name.to_string(),
+                            display_path(name, self.options.display.show_full_paths),
+                        )
+                        .on_hover_text(format!("Select {} for tinting", name));
                     }
                 });
         });

--- a/src/app_impl/ui_helpers.rs
+++ b/src/app_impl/ui_helpers.rs
@@ -17,3 +17,15 @@ pub(crate) fn section_heading(ui: &mut egui::Ui, heading: &str, collapsed: &mut 
     }
     !*collapsed
 }
+
+/// Shortens a path for UI usage if it's desired.
+pub(crate) fn display_path(path: &str, show_full_paths: bool) -> String {
+    if show_full_paths {
+        return path.to_string();
+    }
+    std::path::Path::new(path)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or(path)
+        .to_string()
+}


### PR DESCRIPTION
This cleans up especially the menu panel when you have long paths.

The full paths can always be seen in hover tooltips, or by enabling display of full paths.

The option can be changed in the app settings section, or with an equivalent button in the maps list.