### PR TITLE
Fix clashing -c flag

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,7 +47,7 @@ jobs:
       run: cargo test --profile kittest --verbose --no-default-features -- --show-output
 
   windows:
-    runs-on: [windows-latest]
+    runs-on: [windows-2022]
     steps:
     - uses: actions/checkout@v4
       with:
@@ -55,11 +55,11 @@ jobs:
     - name: Format check
       run: cargo fmt --all -- --check
     - name: Build
-      run: cargo build --profile kittest --verbose --locked
+      run: cargo build --profile kittest --verbose
     - name: Run tests
       # Run tests without kittest_snapshots feature
       # (no wgpu support in CI runner).
-      run: cargo test --profile kittest --verbose --no-default-features --locked -- --show-output
+      run: cargo test --profile kittest --verbose --no-default-features -- --show-output
 
   wasm:
     runs-on: [macos-latest]  # host irrelevant here, but mac is fastest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,7 +47,7 @@ jobs:
       run: cargo test --profile kittest --verbose --no-default-features -- --show-output
 
   windows:
-    runs-on: [windows-2022]
+    runs-on: [windows-latest]
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,11 +55,11 @@ jobs:
     - name: Format check
       run: cargo fmt --all -- --check
     - name: Build
-      run: cargo build --profile kittest --verbose
+      run: cargo build --profile kittest --verbose --locked
     - name: Run tests
       # Run tests without kittest_snapshots feature
       # (no wgpu support in CI runner).
-      run: cargo test --profile kittest --verbose --no-default-features -- --show-output
+      run: cargo test --profile kittest --verbose --no-default-features --locked -- --show-output
 
   wasm:
     runs-on: [macos-latest]  # host irrelevant here, but mac is fastest

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,6 @@ struct Args {
     )]
     alpha: Option<f32>,
     #[clap(
-        short,
         long,
         value_parser = parse_hex_color,
         help = "Hex-color that will be set to transparent in all maps. Example: #FF0012"


### PR DESCRIPTION
-c was already occupied as a shorthand for the --config flag. Clap doesn't seem to complain about such clashes (?).