### PR TITLE
Remove useless ui.add_space in grid layouts

### DIFF
--- a/src/app_impl/canvas_settings.rs
+++ b/src/app_impl/canvas_settings.rs
@@ -2,7 +2,6 @@ use eframe::egui;
 use serde::{Deserialize, Serialize};
 
 use crate::app::{AppState, ViewMode};
-use crate::app_impl::constants::SPACE;
 use crate::app_impl::ui_helpers::section_heading;
 
 const MIN_STACK_SCALE: f32 = 1.0;
@@ -40,7 +39,6 @@ impl AppState {
         if self.options.collapsed.canvas_settings {
             return;
         }
-        ui.add_space(SPACE);
         ui.end_row();
         ui.label("Dark / Light mode");
         // Theme is applied in main update(), to ensure it's also applied when this ui is hidden.

--- a/src/app_impl/grid_settings.rs
+++ b/src/app_impl/grid_settings.rs
@@ -1,7 +1,6 @@
 use eframe::egui;
 
 use crate::app::AppState;
-use crate::app_impl::constants::SPACE;
 use crate::app_impl::ui_helpers::section_heading;
 use crate::grid_options::{GridLineDimension, GridOptions, SubLineVisibility};
 
@@ -14,7 +13,6 @@ impl AppState {
         if self.options.collapsed.grid_settings {
             return;
         }
-        ui.add_space(SPACE);
         ui.end_row();
 
         ui.label("Show grid lines");
@@ -68,7 +66,6 @@ impl AppState {
         if !section_heading(ui, "Tools", &mut self.options.collapsed.tool_settings) {
             return;
         }
-        ui.add_space(SPACE);
         ui.end_row();
         ui.label("Measurement color")
             .on_hover_text("Line color of the measurement tool.");

--- a/src/app_impl/lens_settings.rs
+++ b/src/app_impl/lens_settings.rs
@@ -1,7 +1,6 @@
 use eframe::egui;
 
 use crate::app::AppState;
-use crate::app_impl::constants::SPACE;
 use crate::app_impl::ui_helpers::section_heading;
 use crate::lens::LensOptions;
 
@@ -14,7 +13,6 @@ impl AppState {
         if self.options.collapsed.lens_settings {
             return;
         }
-        ui.add_space(SPACE);
         ui.end_row();
         ui.label("Lens size (meters)");
         ui.add(egui::Slider::new(

--- a/src/app_impl/tint_settings.rs
+++ b/src/app_impl/tint_settings.rs
@@ -4,7 +4,6 @@ use eframe::egui;
 use serde::{Deserialize, Serialize};
 
 use crate::app::AppState;
-use crate::app_impl::constants::SPACE;
 use crate::app_impl::ui_helpers::{display_path, section_heading};
 use crate::render_options::TextureFilter;
 use crate::value_colormap::ColorMap;
@@ -47,7 +46,6 @@ impl AppState {
         if !section_heading(ui, "Blend", &mut self.options.collapsed.tint_settings) {
             return;
         }
-        ui.add_space(SPACE);
         ui.end_row();
 
         let all_key = "< All >".to_string();


### PR DESCRIPTION
Has no effect and also crashes a debug assert in egui.