### PR TITLE
Cache textures and reuse if possible

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ mod path_helpers;
 pub mod persistence;
 mod rect_helpers;
 mod render_options;
+mod texture_cache;
 mod texture_request;
 mod texture_state;
 mod tiles;

--- a/src/render_options.rs
+++ b/src/render_options.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 /// Textures above this size should be cropped.
 pub const fn default_crop_threshold() -> u32 {
-    4000
+    6000
 }
 
 /// Options for image rendering.

--- a/src/texture_cache.rs
+++ b/src/texture_cache.rs
@@ -1,0 +1,82 @@
+use std::collections::HashMap;
+
+use eframe::egui;
+
+use crate::texture_request::TextureRequest;
+use crate::value_interpretation::ValueInterpretation;
+
+/// A cached texture handle with its appearance properties.
+#[derive(Clone)]
+struct CachedTexture {
+    texture_handle: egui::TextureHandle,
+    color_to_alpha: Option<egui::Color32>,
+    thresholding: Option<ValueInterpretation>,
+    texture_options: egui::TextureOptions,
+}
+
+impl CachedTexture {
+    /// Returns true if this cached texture matches the appearance requirements.
+    fn matches_appearance(&self, request: &TextureRequest) -> bool {
+        self.color_to_alpha == request.color_to_alpha
+            && self.thresholding == request.thresholding
+            && self.texture_options == request.texture_options.unwrap_or_default()
+    }
+}
+
+/// Cache for texture handles to avoid reloading textures when switching resolution levels,
+/// unless some appearance properties change and a new texture needs to be created.
+#[derive(Default)]
+pub struct TextureCache {
+    cache: HashMap<String, CachedTexture>,
+}
+
+impl TextureCache {
+    pub fn new() -> Self {
+        Self {
+            cache: HashMap::new(),
+        }
+    }
+
+    fn generate_key(client: &str, pyramid_level: u32) -> String {
+        format!("{}_{}", client, pyramid_level)
+    }
+
+    /// Queries the cache for a texture that matches the client, level, and appearance requirements.
+    /// Returns None on cache-miss.
+    pub fn query(
+        &mut self,
+        client: &str,
+        pyramid_level: u32,
+        request: &TextureRequest,
+    ) -> Option<egui::TextureHandle> {
+        let cache_key = Self::generate_key(client, pyramid_level);
+
+        if let Some(cached_texture) = self.cache.get(&cache_key) {
+            if cached_texture.matches_appearance(request) {
+                return Some(cached_texture.texture_handle.clone());
+            } else {
+                // Remove outdated cache entry.
+                self.cache.remove(&cache_key);
+            }
+        }
+
+        None
+    }
+
+    pub fn store(
+        &mut self,
+        client: &str,
+        pyramid_level: u32,
+        texture_handle: egui::TextureHandle,
+        request: &TextureRequest,
+    ) {
+        let cache_key = Self::generate_key(client, pyramid_level);
+        let cached_texture = CachedTexture {
+            texture_handle,
+            color_to_alpha: request.color_to_alpha,
+            thresholding: request.thresholding,
+            texture_options: request.texture_options.unwrap_or_default(),
+        };
+        self.cache.insert(cache_key, cached_texture);
+    }
+}

--- a/src/texture_request.rs
+++ b/src/texture_request.rs
@@ -113,6 +113,11 @@ pub struct ImagePlacement {
 }
 
 impl RotatedCropRequest {
+    /// Returns true if this request represents a full texture (not a crop).
+    pub fn is_full_texture(&self) -> bool {
+        self.uv[0] == egui::Pos2::ZERO && self.uv[1] == egui::pos2(1.0, 1.0)
+    }
+
     /// Pre-calculate the minimal, unrotated crop that is needed to show the rotated surface in the viewport.
     /// I.e. neither clipping too much nor making the texture unnecessarily large / inefficient.
     /// Enable trace log level to see what is going on (I spent too much time figuring this out).


### PR DESCRIPTION
This avoids some overhead when zooming without appearance changes (changes that don't require a re-upload of a texture) and the level changes.