### PR TITLE
Less shitty looking titlebar with larger macOS Tahoe window buttons

### DIFF
--- a/src/app_impl/constants.rs
+++ b/src/app_impl/constants.rs
@@ -5,4 +5,4 @@ pub const ICON_SIZE: f32 = 20.;
 /// This frees a bit of space and looks more elegant. Available only on macOS.
 pub const CUSTOM_TITLEBAR_SUPPORTED: bool = cfg!(target_os = "macos");
 /// Indentation to make room for window controls when a custom titlebar is used.
-pub const HEADER_PANEL_INDENT: f32 = 65.; // 3 Mac buttons + padding
+pub const HEADER_PANEL_INDENT: f32 = 75.; // 3 Mac buttons + padding


### PR DESCRIPTION
<img width="286" height="122" alt="grafik" src="https://github.com/user-attachments/assets/b212326f-986a-47df-8be2-9346d59073d5" />
<img width="286" height="122" alt="grafik" src="https://github.com/user-attachments/assets/e3919e59-5f2b-40d4-9563-dbcf94bd3167" />

Not perfect but does the job. Looks acceptable on previous OS.
<img width="276" height="146" alt="Bildschirmfoto 2025-09-27 um 01 17 06" src="https://github.com/user-attachments/assets/237318ae-35a1-493c-8590-5e5810601f66" />

Alternative: old size seems still possible, how to get that with egui/winit?